### PR TITLE
ci: publish /docs via gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,17 @@
+name: gh-pages
+on:
+  push:
+    branches: ["**"]   # publish on any branch push
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish docs/ to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs


### PR DESCRIPTION
Adds workflow so pushes publish /docs → gh-pages.